### PR TITLE
1.2.0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,15 @@
+# CHANGELOG
+
+## 1.2.0 (2022-12-06)
+
+### Changes
+
+- Bump Headscale version to the latest ([8fbfa51](https://github.com/kazauwa/ansible-role-headscale/commit/8fbfa516acd54e6cd325973d7c55d7d0243f7ab5))
+- Reload Headscale on config change instead of restarting ([fafae46](https://github.com/kazauwa/ansible-role-headscale/commit/fafae466f9584ce6c0e9fdeb638917507630303a))
+- Update docs for `headscale_enable_routes` and `headscale_exit_nodes` variables ([ac67ff0](https://github.com/kazauwa/ansible-role-headscale/commit/ac67ff0d07954ea7ec8890e587bb97216ba4464d))
+
+## 1.1.0 (2022-05-29)
+
+### Changes
+
+- Add support for enabling routes and exit nodes ([b74e0e7](https://github.com/kazauwa/ansible-role-headscale/commit/b74e0e7f822aa9da90d272a7e3016f8fd39eafee))

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A role that installs and manages [Headscale](https://github.com/juanfont/headsca
 ## Role Variables
 
 - `headscale_version`
-  - Default: `0.15.0`
+  - Default: `0.17.1`
   - Description: version of Headscale to install. List of avaliable versions can be found on [official releases page](https://github.com/juanfont/headscale/releases). Defaults to the latest avaliable.
 - `headscale_arch`
   - Default: `amd64`
@@ -68,7 +68,7 @@ None.
       roles:
         - kazauwa.headscale
       vars:
-        headscale_version: '0.15.0'
+        headscale_version: '0.17.1'
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ A role that installs and manages [Headscale](https://github.com/juanfont/headsca
   - Description: list of namespaces to create, e.g. to use with tagOwners.
 - `headscale_enable_routes`
   - Default: `[]`
-  - Description: list of nodes with advertised routes to enable. Accepts an integer id of headscale node, list of comma-separated routes and an optional comment to output during execution.
+  - Description: list of nodes with advertised routes to enable. Accepts an integer id of headscale node, list of comma-separated routes and an optional comment to output during execution. Used when [autoApprovers](https://tailscale.com/kb/1018/acls/#auto-approvers-for-routes-and-exit-nodes) are not set.
   - Example: `{'id': 14, 'routes': '10.0.0.0/24,10.2.3.4/32', 'comment': 'Gateway to prod'}`
 - `headscale_exit_nodes`
   - Default: `[]`
-  - Description: list of nodes acting as an exit node. Accepts an integer id of headscale node and an optional comment to output during execution.
+  - Description: list of nodes acting as an exit node. Accepts an integer id of headscale node and an optional comment to output during execution. Used when [autoApprovers](https://tailscale.com/kb/1018/acls/#auto-approvers-for-routes-and-exit-nodes) are not set.
   - Example: `{'id': 14, 'comment': 'eu-fra-01'}`
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-headscale_version: '0.15.0'
+headscale_version: '0.17.1'
 headscale_arch: 'amd64'
 headscale_user_name: 'headscale'
 headscale_user_group: '{{ headscale_user_name }}'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,3 +6,9 @@
     enabled: true
     daemon-reload: true
   listen: 'restart headscale'
+
+- name: Reload headscale
+  service:
+    name: headscale
+    state: reloaded
+  listen: 'reload headscale'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: '{{ headscale_user_uid }}'
     group: '{{ headscale_user_gid }}'
     mode: 0600
-  notify: restart headscale
+  notify: reload headscale
 
 - name: Copy ACL policies file
   copy:
@@ -15,7 +15,7 @@
     owner: '{{ headscale_user_uid }}'
     group: '{{ headscale_user_gid }}'
     mode: 0600
-  notify: restart headscale
+  notify: reload headscale
 
 - name: Ensure predefined namespaces exist
   command:

--- a/templates/etc/systemd/system/headscale.service.j2
+++ b/templates/etc/systemd/system/headscale.service.j2
@@ -9,6 +9,7 @@ Environment=GIN_MODE=release
 User={{ headscale_user_name }}
 Group={{ headscale_user_group }}
 ExecStart={{ headscale_binary_path }} serve
+ExecReload=kill -HUP $MAINPID
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
- Bump Headscale version to the latest ([8fbfa51](https://github.com/kazauwa/ansible-role-headscale/commit/8fbfa516acd54e6cd325973d7c55d7d0243f7ab5))
- Reload Headscale on config change instead of restarting ([fafae46](https://github.com/kazauwa/ansible-role-headscale/commit/fafae466f9584ce6c0e9fdeb638917507630303a))
- Update docs for `headscale_enable_routes` and `headscale_exit_nodes` variables ([ac67ff0](https://github.com/kazauwa/ansible-role-headscale/commit/ac67ff0d07954ea7ec8890e587bb97216ba4464d))