### PR TITLE
release v1.3.0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 1.3.0 (2023-02-16)
+
+### Breaking
+
+- Rename `namespaces` to `users` to align with changes to Headscale (see [0.19.0 release notes](https://github.com/juanfont/headscale/blob/main/CHANGELOG.md#0190-2023-01-29)) ([d1a83ac](https://github.com/kazauwa/ansible-role-headscale/commit/d1a83ac74239f32756c8ae4aa0224c4ac01cf930))
+
+### Changes
+
+- Fix triggering changed state in Ansible caused by `headscale_pid_dir` mode ([be60f3c](https://github.com/kazauwa/ansible-role-headscale/commit/be60f3cf31578e68a27e6a86727ad6709c319948))
+- Restart Headscale after update ([3cc93d7](https://github.com/kazauwa/ansible-role-headscale/commit/3cc93d74267212c33dc2f7858247c399db030173))
+
+
 ## 1.2.0 (2022-12-06)
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ None.
       roles:
         - kazauwa.headscale
       vars:
-        headscale_version: '0.17.1'
+        headscale_version: '0.20.0'
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ A role that installs and manages [Headscale](https://github.com/juanfont/headsca
 - `headscale_acl`
   - Default: `{}`
   - Description: yaml formatted ACL policies. **Make sure** that you've read the [docs](https://github.com/juanfont/headscale/tree/main/docs#policy-acls) on how to use this feature.
-- `headscale_namespaces`
+- `headscale_users`
   - Default: `[]`
-  - Description: list of namespaces to create, e.g. to use with tagOwners.
+  - Description: list of users to create, e.g. to use with tagOwners.
 - `headscale_enable_routes`
   - Default: `[]`
   - Description: list of nodes with advertised routes to enable. Accepts an integer id of headscale node, list of comma-separated routes and an optional comment to output during execution. Used when [autoApprovers](https://tailscale.com/kb/1018/acls/#auto-approvers-for-routes-and-exit-nodes) are not set.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-headscale_version: '0.17.1'
+headscale_version: '0.20.0'
 headscale_arch: 'amd64'
 headscale_user_name: 'headscale'
 headscale_user_group: '{{ headscale_user_name }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,6 @@ headscale_directories:
 
 headscale_config: {}
 headscale_acl: {}
-headscale_namespaces: []
+headscale_users: []
 headscale_enable_routes: []
 headscale_exit_nodes: []

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -17,9 +17,9 @@
     mode: 0600
   notify: reload headscale
 
-- name: Ensure predefined namespaces exist
+- name: Ensure predefined users exist
   command:
-    cmd: 'headscale namespaces create {{ item }}'
-  loop: '{{ headscale_namespaces }}'
-  register: namespace_created
-  changed_when: '"Namespace created" in namespace_created.stdout'
+    cmd: 'headscale users create {{ item }}'
+  loop: '{{ headscale_users }}'
+  register: user_created
+  changed_when: '"User created" in user_created.stdout'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,6 +22,7 @@
     owner: '{{ headscale_user_uid }}'
     group: '{{ headscale_user_gid }}'
     mode: 0770
+  notify: restart headscale
 
 - name: Ensure headscale directories exist
   file:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,7 +29,7 @@
     state: directory
     owner: '{{ headscale_user_name }}'
     group: '{{ headscale_user_group }}'
-    mode: 0700
+    mode: 0755
   loop: '{{ headscale_directories }}'
 
 - name: Ensure sqlite exists


### PR DESCRIPTION
### Breaking

- Rename `namespaces` to `users` to align with changes to Headscale (see [0.19.0 release notes](https://github.com/juanfont/headscale/blob/main/CHANGELOG.md#0190-2023-01-29)) ([d1a83ac](https://github.com/kazauwa/ansible-role-headscale/commit/d1a83ac74239f32756c8ae4aa0224c4ac01cf930))

### Changes

- Fix triggering changed state in Ansible caused by `headscale_pid_dir` mode ([be60f3c](https://github.com/kazauwa/ansible-role-headscale/commit/be60f3cf31578e68a27e6a86727ad6709c319948))
- Restart Headscale after update ([3cc93d7](https://github.com/kazauwa/ansible-role-headscale/commit/3cc93d74267212c33dc2f7858247c399db030173))