### PR TITLE
Add support for config template, bump Headscale version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ A role that installs and manages [Headscale](https://github.com/juanfont/headsca
 - `headscale_config`
   - Default: `{}`
   - Description: yaml formatted headscale config, consider using [default config](https://github.com/juanfont/headscale/blob/main/config-example.yaml) as a starting point.
+- `headscale_config_template`
+  - Default: `""`
+  - Description: path to Jinja2 formatted headscale config template. If present, will override `headscale_config`.
 - `headscale_acl`
   - Default: `{}`
   - Description: yaml formatted ACL policies. **Make sure** that you've read the [docs](https://github.com/juanfont/headscale/tree/main/docs#policy-acls) on how to use this feature.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A role that installs and manages [Headscale](https://github.com/juanfont/headsca
 ## Role Variables
 
 - `headscale_version`
-  - Default: `0.20.0`
+  - Default: `0.22.3`
   - Description: version of Headscale to install. List of avaliable versions can be found on [official releases page](https://github.com/juanfont/headscale/releases). Defaults to the latest avaliable.
 - `headscale_arch`
   - Default: `amd64`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ headscale_directories:
   - '{{ headscale_pid_dir }}'
 
 headscale_config: {}
+headscale_config_template: ""
 headscale_acl: {}
 headscale_users: []
 headscale_enable_routes: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-headscale_version: '0.20.0'
+headscale_version: '0.22.3'
 headscale_arch: 'amd64'
 headscale_user_name: 'headscale'
 headscale_user_group: '{{ headscale_user_name }}'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,11 +1,22 @@
 ---
 - name: Copy configuration file
+  when: headscale_config
   copy:
-    content: '{{ headscale_config | to_yaml }}'
-    dest: '{{ headscale_config_dir }}/config.yaml'
-    owner: '{{ headscale_user_uid }}'
-    group: '{{ headscale_user_gid }}'
-    mode: 0600
+    content: "{{ headscale_config | to_yaml }}"
+    dest: "{{ headscale_config_dir }}/config.yaml"
+    owner: "{{ headscale_user_uid }}"
+    group: "{{ headscale_user_gid }}"
+    mode: "0600"
+  notify: reload headscale
+
+- name: Copy configuration file template
+  when: headscale_config_template
+  template:
+    src: "{{ headscale_config_template }}"
+    dest: "{{ headscale_config_dir }}/config.yaml"
+    owner: "{{ headscale_user_uid }}"
+    group: "{{ headscale_user_gid }}"
+    mode: "0600"
   notify: reload headscale
 
 - name: Copy ACL policies file


### PR DESCRIPTION
I wanted to be able to use a template to configure Headscale (since I don't care to put some of the information in it into a public repository). This PR introduces two changes:

- Adds a new `headscale_config_template` variable. This is a path to a template that can be used to configure Headscale. If this template is present, it will override any value in the `headscale_config` variable (since it applies second). This change is documented.
- Bump the Headscale version to the latest, as of the time of this PR (I tried to figure out how to make it just _always_ pull the latest, but due to the naming scheme of the binaries, I don't think that's possible (or at least not easy).