### PR TITLE
support acl as hujson

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,7 +4,7 @@
 	
 ### Breaking
 [reff](https://github.com/juanfont/headscale/blob/a7874af3d0ba48913fa7e5fbffbb38b537bae7b3/CHANGELOG.md?plain=1#L74)
-- YAML files are no longer supported for headscale policy. [#1792](https://github.com/juanfont/headscale/pull/1792)
+- YAML files are no longer supported for headscale policy. [#1792](https://github.com/juanfont/OBheadscale/pull/1792)
   - HuJSON is now the only supported format for policy.
 	
 ### Fixed
@@ -12,7 +12,8 @@
 	
 ### Changed	
 - Changed `headscale_acl` for `headscale_acl_file`. A file is now needed.
-#### Removed
+
+### Removed
 - Removed the capability of having ACL yaml formated to be outputted in the in a file. ([0c79226](https://github.com/kazauwa/ansible-role-headscale/blob/1cbe9432ae53c3042a45506fd48f3dd203e24c97/tasks/configure.yml#L24))
 	
 ## 2.0.0 (2024-03-18)

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,21 +1,18 @@
 # CHANGELOG
 
 ## Unreleased
-	
+
 ### Breaking
 [reff](https://github.com/juanfont/headscale/blob/a7874af3d0ba48913fa7e5fbffbb38b537bae7b3/CHANGELOG.md?plain=1#L74)
 - YAML files are no longer supported for headscale policy. [#1792](https://github.com/juanfont/OBheadscale/pull/1792)
   - HuJSON is now the only supported format for policy.
-	
-### Fixed
-- Fixed the ACL functionality in the ansible role. (https://github.com/kazauwa/ansible-role-headscale/issues/9)
-	
-### Changed	
+
+### Changed
 - Changed `headscale_acl` for `headscale_acl_file`. A file is now needed.
 
 ### Removed
-- Removed the capability of having ACL yaml formated to be outputted in the in a file. ([0c79226](https://github.com/kazauwa/ansible-role-headscale/blob/1cbe9432ae53c3042a45506fd48f3dd203e24c97/tasks/configure.yml#L24))
-	
+- Removed the capability of having ACL YAML formatted to be outputted to a file. ([0c79226](https://github.com/kazauwa/ansible-role-headscale/blob/1cbe9432ae53c3042a45506fd48f3dd203e24c97/tasks/configure.yml#L24))
+
 ## 2.0.0 (2024-03-18)
 
 ### Breaking

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## Unreleased
+	
+### Breaking
+[reff](https://github.com/juanfont/headscale/blob/a7874af3d0ba48913fa7e5fbffbb38b537bae7b3/CHANGELOG.md?plain=1#L74)
+- YAML files are no longer supported for headscale policy. [#1792](https://github.com/juanfont/headscale/pull/1792)
+  - HuJSON is now the only supported format for policy.
+	
+### Fixed
+- Fixed the ACL functionality in the ansible role. (https://github.com/kazauwa/ansible-role-headscale/issues/9)
+	
+### Changed	
+- Changed `headscale_acl` for `headscale_acl_file`. A file is now needed.
+#### Removed
+- Removed the capability of having ACL yaml formated to be outputted in the in a file. ([0c79226](https://github.com/kazauwa/ansible-role-headscale/blob/1cbe9432ae53c3042a45506fd48f3dd203e24c97/tasks/configure.yml#L24))
+	
 ## 2.0.0 (2024-03-18)
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ansible-galaxy install kazauwa.headscale
 ## Role Variables
 
 - `headscale_version`
-  - Default: `0.22.3`
+  - Default: `0.23.0`
   - Description: version of Headscale to install. List of avaliable versions can be found on [official releases page](https://github.com/juanfont/headscale/releases). Defaults to the latest avaliable.
 - `headscale_arch`
   - Default: `amd64`
@@ -52,9 +52,9 @@ ansible-galaxy install kazauwa.headscale
 - `headscale_config_template`
   - Default: `""`
   - Description: path to Jinja2 formatted headscale config template. If present, will override `headscale_config`.
-- `headscale_acl`
-  - Default: `{}`
-  - Description: yaml formatted ACL policies. **Make sure** that you've read the [docs](https://github.com/juanfont/headscale/tree/main/docs#policy-acls) on how to use this feature.
+- `headscale_acl_file`
+  - Default: `""`
+  - Description: path to HuJSON formatted headscale acl file.
 - `headscale_users`
   - Default: `[]`
   - Description: list of users to create, e.g. to use with tagOwners.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ ansible-galaxy install kazauwa.headscale
   - Description: path to Jinja2 formatted headscale config template. If present, will override `headscale_config`.
 - `headscale_acl_file`
   - Default: `""`
-  - Description: path to HuJSON formatted headscale acl file.
+  - Description: path to HuJSON formatted headscale acl file. **Make sure** that you've read the [docs](https://github.com/juanfont/headscale/blob/main/docs/ref/acls.md) on how to use this feature and the HuJSON syntax [acl-syntax](https://tailscale.com/kb/1337/acl-syntax).
 - `headscale_users`
   - Default: `[]`
   - Description: list of users to create, e.g. to use with tagOwners.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-headscale_version: '0.22.3'
+headscale_version: '0.23.0'
 headscale_os: 'linux'
 headscale_arch: 'amd64'
 headscale_user_name: 'headscale'
@@ -19,7 +19,7 @@ headscale_directories:
 
 headscale_config: {}
 headscale_config_template: ''
-headscale_acl: {}
+headscale_acl_file: ''
 headscale_users: []
 headscale_enable_routes: []
 headscale_exit_nodes: []

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -23,7 +23,7 @@
   when: headscale_acl_file
   ansible.builtin.copy:
     src:  '{{ headscale_acl_file }}'
-    dest: '{{ headscale_config_dir }}/acl.json'
+    dest: '{{ headscale_config_dir }}/acl.hujson'
     owner: '{{ headscale_user_uid }}'
     group: '{{ headscale_user_gid }}'
     mode: '0600'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -18,11 +18,11 @@
     group: '{{ headscale_user_gid }}'
     mode: '0600'
   notify: restart headscale
-  
+
 - name: Copy ACL policies file
   when: headscale_acl_file
   ansible.builtin.copy:
-    src:  '{{ headscale_acl_file }}'
+    src: 'x{{ headscale_acl_file }}'
     dest: '{{ headscale_config_dir }}/acl.hujson'
     owner: '{{ headscale_user_uid }}'
     group: '{{ headscale_user_gid }}'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -22,7 +22,7 @@
 - name: Copy ACL policies file
   when: headscale_acl_file
   ansible.builtin.copy:
-    src: 'x{{ headscale_acl_file }}'
+    src: '{{ headscale_acl_file }}'
     dest: '{{ headscale_config_dir }}/acl.hujson'
     owner: '{{ headscale_user_uid }}'
     group: '{{ headscale_user_gid }}'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -18,11 +18,12 @@
     group: '{{ headscale_user_gid }}'
     mode: '0600'
   notify: restart headscale
-
+  
 - name: Copy ACL policies file
+  when: headscale_acl_file
   ansible.builtin.copy:
-    content: '{{ headscale_acl | to_yaml }}'
-    dest: '{{ headscale_config_dir }}/acl.yaml'
+    src:  '{{ headscale_acl_file }}'
+    dest: '{{ headscale_config_dir }}/acl.json'
     owner: '{{ headscale_user_uid }}'
     group: '{{ headscale_user_gid }}'
     mode: '0600'


### PR DESCRIPTION
Quick fix for my needs

Notes:
- Need to validate additional breaking changes with the version update to 0.23.0.

- Removed `headscale_acl` as YAML:
   - Jinja templates are no longer used for this.